### PR TITLE
Enabling feature gates

### DIFF
--- a/backend/kernelspace/dualstack.go
+++ b/backend/kernelspace/dualstack.go
@@ -20,8 +20,8 @@ limitations under the License.
 package kernelspace
 
 import (
-	"strings"
 	"k8s.io/klog/v2"
+	"strings"
 
 	"github.com/Microsoft/hcsshim/hcn"
 )
@@ -90,7 +90,7 @@ func (t DualStackCompatTester) DualStackCompatible(networkName string) bool {
 		return false
 	}
 
-	if true /* utilfeature.DefaultFeatureGate.Enabled(kubefeatures.WinOverlay) */ && isOverlay(networkInfo) {
+	if isOverlay(networkInfo) {
 		// Overlay (VXLAN) networks on Windows do not support dual-stack networking today
 		klog.InfoS("Winoverlay does not support dual-stack, falling back to single-stack")
 		return false

--- a/backend/kernelspace/proxier.go
+++ b/backend/kernelspace/proxier.go
@@ -338,10 +338,9 @@ func NewProxier(
 
 	klog.V(1).InfoS("Hns Network loaded", "hnsNetworkInfo", hnsNetworkInfo)
 	isDSR := config.EnableDSR
-	// todo(knabben) - review feature gates
-	/*if isDSR && !utilfeature.DefaultFeatureGate.Enabled(kubefeatures.WinDSR) {
-		return nil, fmt.Errorf("WinDSR feature gate not enabled")
-	}*/
+	if !isDSR {
+		return nil, fmt.Errorf("WinDSR option is not enabled. Use --enable-dsr.")
+	}
 	err = hcn.DSRSupported()
 	if isDSR && err != nil {
 		return nil, err
@@ -350,10 +349,6 @@ func NewProxier(
 	var sourceVip string
 	var hostMac string
 	if isOverlay(hnsNetworkInfo) {
-		// todo(knabben) - fix feature gates
-		/*if !true /*utilfeature.DefaultFeatureGate.Enabled(kubefeatures.WinOverlay) {
-			return nil, fmt.Errorf("WinOverlay feature gate not enabled")
-		}*/
 		err = hcn.RemoteSubnetSupported()
 		if err != nil {
 			return nil, err

--- a/backend/kernelspace/service.go
+++ b/backend/kernelspace/service.go
@@ -26,7 +26,6 @@ import (
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
-
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/events"
@@ -232,14 +231,11 @@ func (info *BaseServiceInfo) HintsAnnotation() string {
 
 func (sct *ServiceChangeTracker) newBaseServiceInfo(port *localv1.PortMapping, service *localv1.Service) *BaseServiceInfo {
 	nodeLocalExternal := false
-	if RequestsOnlyLocalTraffic(service) {
+	if ExternalPolicyLocal(service) {
 		nodeLocalExternal = true
 	}
-	nodeLocalInternal := false
-	//TODO : CHECK InternalTrafficPolicy
-	// if utilfeature.DefaultFeatureGate.Enabled(features.ServiceInternalTrafficPolicy) {
-	// 	nodeLocalInternal = apiservice.RequestsOnlyLocalTrafficForInternal(service)
-	// }
+
+	nodeLocalInternal := InternalPolicyLocal(service)
 
 	v1Proto := v1.ProtocolTCP
 	if port.Protocol == localv1.Protocol_UDP {

--- a/backend/kernelspace/util.go
+++ b/backend/kernelspace/util.go
@@ -359,13 +359,18 @@ func GetClusterIPByFamily(ipFamily v1.IPFamily, service *localv1.Service) string
 	return ""
 }
 
-// RequestsOnlyLocalTraffic checks if service requests OnlyLocal traffic.
-func RequestsOnlyLocalTraffic(service *localv1.Service) bool {
+// ExternalPolicyLocal checks if service has ETP = Local.
+func ExternalPolicyLocal(service *localv1.Service) bool {
 	if service.Type != string(v1.ServiceTypeLoadBalancer) &&
 		service.Type != string(v1.ServiceTypeNodePort) {
 		return false
 	}
 	return service.ExternalTrafficToLocal
+}
+
+// InternalPolicyLocal checks if service has ITP = Local.
+func InternalPolicyLocal(service *localv1.Service) bool {
+	return service.InternalTrafficToLocal
 }
 
 // MapIPsByIPFamily maps a slice of IPs to their respective IP families (v4 or v6)


### PR DESCRIPTION
Fixes #11 

Moving feature flags to plain flags, the user can force `--flag=false` to disable it. 

Current flags available:
```
	--enable-dsr - Set this flag to enable DSR
	--enable-overlay - Set this flag to enable WinOverlay
```