### PR TITLE
explicitly set DOCKER_CLI_EXPERIMENTAL=enabled build_windows-container.sh

### DIFF
--- a/hack/build_windows_container.sh
+++ b/hack/build_windows_container.sh
@@ -15,6 +15,8 @@ set -e
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
 args=$(getopt -o p -l push -- "$@")
 eval set -- "$args"
 


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

This should fix the build error in https://testgrid.k8s.io/sig-windows-push-images#post-windows-service-proxy-push-images

/assign @jsturtevant @knabben 