### PR TITLE
Updating cloudbuild.yaml to use a container image that buildx support

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,7 @@ timeout: 1200s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230111-cd1b3caf9c'
     entrypoint: bash
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

/assign @knabben @jsturtevant @jayunit100 

> Downloaded newer image for gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55
bash-5.1# docker version
Client:
 Version:           20.10.7
 API version:       1.41
 Go version:        go1.16.8
 Git commit:        f0df35096d5f5e6b559b42c7fde6c65a2909f7c5
 Built:             Sat Sep 11 14:51:17 2021
 OS/Arch:           linux/amd64
 Context:           default
 Experimental:      true

vs

> Status: Downloaded newer image for gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230111-cd1b3caf9c
d7643e88e67e:/workspace# docker version
Client:
 Version:           20.10.21
 API version:       1.41
 Go version:        go1.19.4
 Git commit:        baeda1f82a10204ec5708d5fbba130ad76cfee49
 Built:             Tue Dec 13 21:59:04 2022
 OS/Arch:           linux/amd64
 Context:           default
 Experimental:      true