### PR TITLE
feat: allow to override kubeNetwork

### DIFF
--- a/charts/templates/DaemonSet.yaml
+++ b/charts/templates/DaemonSet.yaml
@@ -66,7 +66,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: KUBE_NETWORK
-              value: Calico
+              value: {{ .Values.cni.kubeNetwork }}
           volumeMounts:
           - mountPath: /kubeconfig.conf
             name: kube-proxy

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -11,14 +11,16 @@ image:
 namespace: kube-system
 serviceAccount: kube-proxy
 
-securityContext: 
+securityContext:
   runAsUserName: NT AUTHORITY\\system
 
 loglevel: 4
 
 cni:
   WinOverlay: true
-  
+  # Adjust this value to match Network name created by CNI provider
+  kubeNetwork: "Calico"
+
 sourcevipImage:
   repository: gcr.io/k8s-staging-win-svc-proxy/kube-proxy:sourcevip-latest
   pullPolicy: Always


### PR DESCRIPTION
Hi!

I would like to add support for changing kubeNetwork name. It covers the scenario where the CNI of choice is not Calico. The default value ensures that this change is not breaking. 

### Verification

```
$ helm template kube-proxy-windows . --set cni.kubeNetwork=azure --set --set cni.WinOverlay=false | kubectl apply -f -

$ kubectl get pods -n kube-system | grep kube-proxy-windows
kube-proxy-windows-c9hd4                    1/1     Running   0              14h
kube-proxy-windows-jb55q                    1/1     Running   0              14h
kube-proxy-windows-xlprg                    1/1     Running   0              14h

$ kubectl logs -f kube-proxy-windows-jb55q  -n kube-system
...
I0507 07:15:09.702772    6944 hns.go:312] "Queried load balancers" count=18
I0507 07:15:09.702772    6944 proxier.go:1242] "Syncing Policies"
I0507 07:15:09.702772    6944 proxier.go:1177] "Syncing proxy rules complete" elapsed="13.8497ms"
I0507 07:15:09.702772    6944 proxier.go:1177] "Syncing proxy rules complete" elapsed="13.7926ms"
I0507 07:15:09.702772    6944 bounded_frequency_runner.go:296] sync-runner: ran, next possible in 1s, periodic in 30s
I0507 07:15:09.702772    6944 bounded_frequency_runner.go:296] sync-runner: ran, next possible in 1s, periodic in 30s
```